### PR TITLE
Push back user location blue dot to prevent blocking call out view.

### DIFF
--- a/OneBusAway/ui/map/OBAMapViewController.m
+++ b/OneBusAway/ui/map/OBAMapViewController.m
@@ -365,7 +365,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 - (void)mapView:(MKMapView *)mapView regionDidChangeAnimated:(BOOL)animated {
     if (mapView.userLocation) {
         UIView *annotationView = [mapView viewForAnnotation:mapView.userLocation];
-        [annotationView.superview bringSubviewToFront:annotationView];
+        [annotationView.superview sendSubviewToBack:annotationView];
     }
 
     [self.mapRegionManager mapView:mapView regionDidChangeAnimated:animated];
@@ -568,7 +568,7 @@ static const double kStopsInRegionRefreshDelayOnDrag = 0.1;
 
 - (void)refreshCurrentLocation {
     CLLocation *location = self.locationManager.currentLocation;
-
+    
     if (location) {
         if (self.mapRegionManager.lastRegionChangeWasProgrammatic) {
             double radius = MAX(location.horizontalAccuracy, OBAMinMapRadiusInMeters);


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-iphone/issues/1091 - Fix z order for annotations and callouts on the map

* Define behavior: The blue dot should always be below the call out views,
so it won't block the call out views when user location gets updated.
User will never lose track of their own location because we have a button that
takes them back to where they are.

* In the OBAMapViewController regionDidChangeAnimated, instead of
bringSubviewToFront, I use sendSubviewToBack to push back the blue dot.