### PR TITLE
Update Mark All as Read button text color to obaGreen color.

### DIFF
--- a/OneBusAway/ui/regional_alerts/RegionalAlertsViewController.swift
+++ b/OneBusAway/ui/regional_alerts/RegionalAlertsViewController.swift
@@ -29,6 +29,7 @@ class RegionalAlertsViewController: OBAStaticTableViewController {
         self.hidesBottomBarWhenPushed = true
         let spacer = UIBarButtonItem.init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         let markReadButton = UIBarButtonItem.init(title:  NSLocalizedString("regional_alerts_controller.mark_all_as_read", comment: "Mark All as Read toolbar button title"), style: .plain, target: self, action: #selector(markAllAsRead))
+        markReadButton.setTitleTextAttributes([NSForegroundColorAttributeName: OBATheme.obaGreen], for: .normal)
         self.toolbarItems = [spacer, markReadButton]
     }
 


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-iphone/issues/1100 - Tint color of "Mark All" button is wrong

* Can't directly use markReadButton.tintColor, instead we need to
use setTitleTextAttribute to change the text color.